### PR TITLE
allowing ingestion of meetup events without location set

### DIFF
--- a/src/django_project/tests/unit/web/test_model_crud.py
+++ b/src/django_project/tests/unit/web/test_model_crud.py
@@ -93,6 +93,17 @@ class EventTests(TestCase):
         self.assertEqual(getattr(row, "location_address"), updated_value)
         self.assertNotEqual(getattr(row, "location_address"), original_value)
 
+    def test_create_without_location(self):
+        """verify event can be created without location fields"""
+        row = self.model.objects.create(
+            name="Locationless event",
+            start_datetime="2026-06-24T00:00:00Z",
+            location_name=None,
+            location_address=None,
+        )
+        self.assertIsNone(row.location_name)
+        self.assertIsNone(row.location_address)
+
     def test_update_location_name(self):
         """verify location_name (CharField) can be updated"""
         row = self.bake()

--- a/src/django_project/web/migrations/0005_alter_event_location_fields_nullable.py
+++ b/src/django_project/web/migrations/0005_alter_event_location_fields_nullable.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("web", "0004_alter_event_end_datetime"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="event",
+            name="location_name",
+            field=models.CharField(
+                blank=True,
+                help_text="name of location where this event is being hosted",
+                max_length=64,
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="event",
+            name="location_address",
+            field=models.CharField(
+                blank=True,
+                help_text="address of location where this event is being hosted",
+                max_length=256,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/django_project/web/models.py
+++ b/src/django_project/web/models.py
@@ -20,11 +20,13 @@ class Event(HandyHelperBaseModel):
     location_name = models.CharField(
         max_length=64,
         blank=True,
+        null=True,
         help_text="name of location where this event is being hosted",
     )
     location_address = models.CharField(
         max_length=256,
         blank=True,
+        null=True,
         help_text="address of location where this event is being hosted",
     )
     map_link = models.URLField(

--- a/src/django_project/web/tasks.py
+++ b/src/django_project/web/tasks.py
@@ -100,6 +100,9 @@ def ingest_future_meetup_events(group_pk) -> str:
             event_info = get_event_information(event_link)
             event_info["group"] = group
             if event_info:
+                event_info.setdefault("location_name", "")
+                event_info.setdefault("location_address", "")
+                event_info.setdefault("map_link", "")
                 if not event_info.get("name", None):
                     logging.error(f"error parsing name for event hosted by {group.name}; data = {event_info}")
                     continue

--- a/src/django_project/web/templates/web/partials/li/events.htm
+++ b/src/django_project/web/templates/web/partials/li/events.htm
@@ -14,8 +14,9 @@
                         <span class="text-secondary" style="font-size: 75%;">{{ row.group.name }}</span>
                     </div>
                     <div class="col-12 col-sm-4 mb-1 text-secondary text-start text-sm-end">
-                        {% if row.location_address %}{{ row.location_name }}<br/>
-                        <span class="text-muted" style="font-size: 75%;">{{ row.location_address }}</span>
+                        {% if row.location_name or row.location_address %}
+                        {{ row.location_name }}{% if row.location_address %}<br/>
+                        <span class="text-muted" style="font-size: 75%;">{{ row.location_address }}</span>{% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/src/django_project/web/templates/web/partials/li/events.htm
+++ b/src/django_project/web/templates/web/partials/li/events.htm
@@ -14,8 +14,9 @@
                         <span class="text-secondary" style="font-size: 75%;">{{ row.group.name }}</span>
                     </div>
                     <div class="col-12 col-sm-4 mb-1 text-secondary text-start text-sm-end">
-                        {{ row.location_name }}<br/>
+                        {% if row.location_address %}{{ row.location_name }}<br/>
                         <span class="text-muted" style="font-size: 75%;">{{ row.location_address }}</span>
+                        {% endif %}
                     </div>
                 </div>
             </li>


### PR DESCRIPTION
## **User description**
## Pull Request

### Description:
Allowing ingestion of meetup events without location set

### Checklist:
- [x] All code quality checks pass
- [x] Code follows the project's style guide
- [ ] Documentation has been updated


### Testing:
- [x] Existing tests provided necessary coverage
- [x] Manual or ad-hoc testing has been performed
- [x] Applicable tests have been added/updated
- [ ] This change does not require testing


___

## **CodeAnt-AI Description**
Let meetup events be saved and shown without a location

### What Changed
- Meetup events can now be ingested even when no location name or address is provided
- Event records now accept missing location fields instead of rejecting them
- The event list hides location details when no address is available, so blank location text no longer appears

### Impact
`✅ Fewer missed meetup imports`
`✅ Cleaner event listings`
`✅ Locationless events can be published`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
